### PR TITLE
CZ-191 Analisar como gerar arquivo ABI no Neo BOA

### DIFF
--- a/boa/abi.py
+++ b/boa/abi.py
@@ -1,0 +1,18 @@
+ByteArray = 'ByteArray'
+Integer = 'Integer'
+Boolean = 'Boolean'
+String = 'String'
+Array = 'Array'
+Struct = 'Struct'
+Map = 'Map'
+Interface = 'Interface'
+Any = 'Any'
+Void = 'Void'
+
+
+def method(*args):
+    return None
+
+
+def entry_point(*args):
+    return None

--- a/boa/abi.py
+++ b/boa/abi.py
@@ -1,3 +1,4 @@
+# write clear when using as params for @abi_entry_point and @abi_method
 ByteArray = 'ByteArray'
 Integer = 'Integer'
 Boolean = 'Boolean'
@@ -9,10 +10,27 @@ Interface = 'Interface'
 Any = 'Any'
 Void = 'Void'
 
+types = {
+    'ByteArray': 'ByteArray',
+    'Integer': 'Integer',
+    'Boolean': 'Boolean',
+    'String': 'String',
+    'Array': 'Array',
+    'Struct': 'Struct',
+    'Map': 'Map',
+    'Interface': 'Interface',
+    'Any': 'Any',
+    'Void': 'Void'
+}
 
-def method(*args):
+
+def is_abi_type(value):
+    return value in types
+
+
+def abi_method(*args):
     return None
 
 
-def entry_point(*args):
+def abi_entry_point(*args):
     return None

--- a/boa/code/ast_preprocess.py
+++ b/boa/code/ast_preprocess.py
@@ -53,4 +53,11 @@ def preprocess_method_body(source_code_obj):
     RewriteDicts.updated_dicts = []
     RewriteDicts.last_store_name = None
 
-    return bc[0].arg, dlist
+    block_code = get_code_block(bc)
+    return block_code.arg, dlist
+
+
+def get_code_block(blocks):
+    for block in blocks:
+        if inspect.iscode(block.arg):
+            return block

--- a/boa/code/method.py
+++ b/boa/code/method.py
@@ -113,7 +113,7 @@ class method(object):
         self.start_line_no = self.block[method_block_index].lineno
         self.code_object = self.block[method_block_index].arg
 
-        #        dis.dis(code_object)
+#        dis.dis(code_object)
         self.code, self.dictionary_defs = preprocess_method_body(self.code_object)
 
         self.bytecode = Bytecode.from_code(self.code)

--- a/boa/code/method.py
+++ b/boa/code/method.py
@@ -110,6 +110,9 @@ class method(object):
         self._extra = extra
 
         method_block_index = self.get_code_block_index(self.block)
+        if method_block_index is None:
+            raise Exception('Block of code of a method from %s module was not found', self.module_name)
+
         self.name = self.block[method_block_index + 1].arg
         self._id = uuid3(UUID('{baa187e0-2c51-4ef6-aa42-b3421c22d5e1}'), self.full_name)
         self.start_line_no = self.block[method_block_index].lineno

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -282,6 +282,10 @@ class Module(object):
                         vmtoken.data = param_ret_counts + jump_len.to_bytes(4, 'little', signed=True)
                 else:
                     raise Exception("Target method %s not found" % vmtoken.target_method)
+        
+        # abi methods decorator is used, but there is no abi entry point decorator
+        if len(self.abi_methods) > 0 and self.abi_entry_point is None:
+            raise Exception("ABI entry point not found")
 
     def to_s(self):
         """
@@ -385,8 +389,11 @@ class Module(object):
         self.abi_methods[method.full_name] = args_types
 
     def set_abi_entry_point(self, method, types):
-        self.include_abi_method(method, types)
-        self.abi_entry_point = method.full_name
+        if self.abi_entry_point is None:
+            self.include_abi_method(method, types)
+            self.abi_entry_point = method.full_name
+        else:
+            raise Exception("Only one method should be entry point")
 
     def export_debug(self, output_path):
         """

--- a/boa/compiler.py
+++ b/boa/compiler.py
@@ -104,6 +104,7 @@ class Compiler(object):
 
         Compiler.write_file(data, output_path)
         compiler.entry_module.export_debug(output_path)
+        compiler.entry_module.export_abi_json(output_path)
 
         return data
 

--- a/boa/util.py
+++ b/boa/util.py
@@ -18,19 +18,29 @@ class BlockType():
 
 
 def get_block_type(block):
-
+    default = BlockType.UNKNOWN
     for instr in block:
         if instr.opcode == pyop.LOAD_NAME and instr.arg == 'RegisterAction':
+            if default != BlockType.UNKNOWN:
+                return default
             return BlockType.ACTION_REG
         elif instr.opcode == pyop.LOAD_NAME and instr.arg == 'RegisterAppCall':
+            if default != BlockType.UNKNOWN:
+                return default
             return BlockType.APPCALL_REG
         elif instr.opcode in [pyop.IMPORT_FROM, pyop.IMPORT_NAME, pyop.IMPORT_STAR]:
+            if default != BlockType.UNKNOWN:
+                return default
             return BlockType.IMPORT_ITEM
         elif instr.opcode == pyop.MAKE_FUNCTION:
             return BlockType.MAKE_FUNCTION
         elif instr.opcode == pyop.LOAD_BUILD_CLASS:
+            if default != BlockType.UNKNOWN:
+                return default
             return BlockType.MAKE_CLASS
         elif instr.opcode == pyop.CALL_FUNCTION:
-            return BlockType.CALL_FUNCTION
+            if default != BlockType.UNKNOWN:
+                return default
+            default = BlockType.CALL_FUNCTION
 
-    return BlockType.UNKNOWN
+    return default

--- a/boa_test/example/AbiMethods1.py
+++ b/boa_test/example/AbiMethods1.py
@@ -1,0 +1,16 @@
+from boa.abi import *
+
+
+@abi_entry_point(String, Array, Any)
+def main(operation, args):
+    if operation == 'add':
+        a = args[0]
+        b = args[1]
+        return add(a, b)
+    else:
+        return False
+
+
+@abi_method(Integer, Integer, Integer)
+def add(a, b):
+    return a + b

--- a/boa_test/example/AbiMethods2.py
+++ b/boa_test/example/AbiMethods2.py
@@ -1,0 +1,15 @@
+from boa.abi import *
+
+
+@abi_entry_point(String, Array, Any)
+def main(operation, args):
+    if operation == 'add':
+        a = args[0]
+        b = args[1]
+        return add(a, b)
+    else:
+        return False
+
+
+def add(a, b):
+    return a + b

--- a/boa_test/example/AbiMethods3.py
+++ b/boa_test/example/AbiMethods3.py
@@ -1,0 +1,15 @@
+from boa.abi import *
+
+
+@abi_method(String, Array, Any)
+def main(operation, args):
+    if operation == 'add':
+        a = args[0]
+        b = args[1]
+        return add(a, b)
+    else:
+        return False
+
+
+def add(a, b):
+    return a + b

--- a/boa_test/example/AbiMethods4.py
+++ b/boa_test/example/AbiMethods4.py
@@ -1,0 +1,16 @@
+from boa.abi import *
+
+
+@abi_entry_point(String, Array, Any)
+def main(operation, args):
+    if operation == 'add':
+        a = args[0]
+        b = args[1]
+        return add(a, b)
+    else:
+        return False
+
+
+@abi_entry_point(Integer, Integer, Integer)
+def add(a, b):
+    return a + b

--- a/boa_test/example/AbiMethods5.py
+++ b/boa_test/example/AbiMethods5.py
@@ -1,0 +1,15 @@
+from boa.abi import *
+
+
+@abi_entry_point(String, Array, ByteArray, Any)
+def main(operation, args):
+    if operation == 'add':
+        a = args[0]
+        b = args[1]
+        return add(a, b)
+    else:
+        return False
+
+
+def add(a, b):
+    return a + b

--- a/boa_test/example/AbiMethods6.py
+++ b/boa_test/example/AbiMethods6.py
@@ -1,0 +1,15 @@
+from boa.abi import *
+
+
+@abi_entry_point(String)
+def main(operation, args):
+    if operation == 'add':
+        a = args[0]
+        b = args[1]
+        return add(a, b)
+    else:
+        return False
+
+
+def add(a, b):
+    return a + b

--- a/boa_test/example/AbiMethods7.py
+++ b/boa_test/example/AbiMethods7.py
@@ -1,0 +1,15 @@
+from boa.abi import *
+
+
+@abi_entry_point(String, Array)
+def main(operation, args):
+    if operation == 'add':
+        a = args[0]
+        b = args[1]
+        return add(a, b)
+    else:
+        return False
+
+
+def add(a, b):
+    return a + b

--- a/boa_test/tests/test_abi_methods.py
+++ b/boa_test/tests/test_abi_methods.py
@@ -1,0 +1,94 @@
+import json
+from boa.compiler import Compiler
+from boa_test.tests.boa_test import BoaTest
+
+
+class TestContract(BoaTest):
+    def test_abi_methods_success(self):
+        path = '%s/boa_test/example/AbiMethods1.py' % TestContract.dirname
+        output = Compiler.load(path).default
+        json_file = json.loads(output.generate_abi_json('AbiMethods1.avm', 'test'))
+
+        entry_point = json_file['entrypoint']
+        self.assertEqual(entry_point, 'main')
+        functions = json_file['functions']
+        self.assertEqual(len(functions), 2)
+
+        main_function = functions[0]
+        main_params = main_function['parameters']
+        self.assertEqual(main_function['name'], 'main')
+        self.assertEqual(main_function['returnType'], 'Any')
+        self.assertEqual(len(main_params), 2)
+        self.assertEqual(main_params[0]['name'], 'operation')
+        self.assertEqual(main_params[0]['type'], 'String')
+        self.assertEqual(main_params[1]['name'], 'args')
+        self.assertEqual(main_params[1]['type'], 'Array')
+
+        add_function = functions[1]
+        add_params = add_function['parameters']
+        self.assertEqual(add_function['name'], 'add')
+        self.assertEqual(add_function['returnType'], 'Integer')
+        self.assertEqual(len(add_params), 2)
+        self.assertEqual(add_params[0]['name'], 'a')
+        self.assertEqual(add_params[0]['type'], 'Integer')
+        self.assertEqual(add_params[1]['name'], 'b')
+        self.assertEqual(add_params[1]['type'], 'Integer')
+
+    def test_abi_methods_only_entry_point(self):
+        path = '%s/boa_test/example/AbiMethods2.py' % TestContract.dirname
+        output = Compiler.load(path).default
+        json_file = json.loads(output.generate_abi_json('AbiMethods2.avm', 'test'))
+
+        entry_point = json_file['entrypoint']
+        self.assertEqual(entry_point, 'main')
+        functions = json_file['functions']
+        self.assertEqual(len(functions), 1)
+
+        main_function = functions[0]
+        main_params = main_function['parameters']
+        self.assertEqual(main_function['name'], 'main')
+        self.assertEqual(main_function['returnType'], 'Any')
+        self.assertEqual(len(main_params), 2)
+        self.assertEqual(main_params[0]['name'], 'operation')
+        self.assertEqual(main_params[0]['type'], 'String')
+        self.assertEqual(main_params[1]['name'], 'args')
+        self.assertEqual(main_params[1]['type'], 'Array')
+
+    def test_abi_methods_without_entry_point(self):
+        path = '%s/boa_test/example/AbiMethods3.py' % TestContract.dirname
+        output = Compiler.load(path).default
+        self.assertEqual(len(output.abi_methods), 1)
+        self.assertEqual(output.abi_entry_point, None)
+        self.assertRaises(Exception, output.write)
+
+    def test_abi_methods_two_entry_points(self):
+        path = '%s/boa_test/example/AbiMethods4.py' % TestContract.dirname
+        self.assertRaises(Exception, Compiler.load, path)
+
+    def test_abi_method_more_types_than_arguments(self):
+        path = '%s/boa_test/example/AbiMethods5.py' % TestContract.dirname
+        self.assertRaises(Exception, Compiler.load, path)
+
+    def test_abi_method_less_types_than_arguments(self):
+        path = '%s/boa_test/example/AbiMethods6.py' % TestContract.dirname
+        self.assertRaises(Exception, Compiler.load, path)
+
+    def test_abi_method_without_return_type(self):
+        path = '%s/boa_test/example/AbiMethods7.py' % TestContract.dirname
+        output = Compiler.load(path).default
+        json_file = json.loads(output.generate_abi_json('AbiMethods7.avm', 'test'))
+
+        entry_point = json_file['entrypoint']
+        self.assertEqual(entry_point, 'main')
+        functions = json_file['functions']
+        self.assertEqual(len(functions), 1)
+
+        main_function = functions[0]
+        main_params = main_function['parameters']
+        self.assertEqual(main_function['name'], 'main')
+        self.assertEqual(main_function['returnType'], 'Void')
+        self.assertEqual(len(main_params), 2)
+        self.assertEqual(main_params[0]['name'], 'operation')
+        self.assertEqual(main_params[0]['type'], 'String')
+        self.assertEqual(main_params[1]['name'], 'args')
+        self.assertEqual(main_params[1]['type'], 'Array')


### PR DESCRIPTION
**What current issue(s) from Github does this address?**
[CityOfZion/neo-boa#124](https://github.com/CityOfZion/neo-boa/issues/124)

**What problem does this PR solve?**
Implement the generation of the .abi.json needed to Neo Visual DevTracker provide a better developer experience for invoking smart contracts

**How did you solve this problem?**
I implemented two decorators to identify the methods that should be included in the .abi.json with the information about parameters and return type:
- ``@abi_method(types)`` to identify the methods that should be included
- ``@abi_entry_point(types)`` to identify which method is the entry point

**Are there any special changes in the code that we should be aware of?**
When a decorator is used, the previous implementation didn't get the code of the method because it was used the first element in ``self.block`` in ``method.py``. I implemented a method to get the index of the block with the code. Changes [here](https://github.com/simplitech/neo-boa/blob/generate_abi_file/boa/code/method.py#L110-L114) and [here](https://github.com/simplitech/neo-boa/blob/generate_abi_file/boa/code/ast_preprocess.py#L56-L63).

**Is there anything else we should know?**
The ``@abi_entry_point(types)`` can be used only once. If any ``@abi_method(types)`` decorator is used, it must have ``@abi_entry_point(types)`` decorator
