### PR TITLE
Change the output path of .abi file to be the same as the others files created

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ from boa.compiler import Compiler
 Compiler.load_and_save('path/to/your/file.py')
 ```
 
+Or navigate into `boa` directory and use the command:
+
+```
+cli.py path/to/your/file.py
+```
+
 For legacy functionality without NEP8 stack isolation compatibility, use the following:
 
 ```

--- a/boa/code/module.py
+++ b/boa/code/module.py
@@ -471,7 +471,7 @@ class Module(object):
         avm_name = os.path.splitext(os.path.basename(output_path))[0]
 
         abi_info = self.generate_abi_json(avm_name, file_hash)
-        abi_json_filename = os.path.basename(output_path.replace('.avm', '.abi.json'))
+        abi_json_filename = output_path.replace('.avm', '.abi.json')
 
         with open(abi_json_filename, 'w+') as out_file:
             out_file.write(abi_info)


### PR DESCRIPTION
**What problem does this PR solve?**
It creates the .abi file in the same path as the .avm and .avmdbgnfo instead of where the project is.

**How did you solve this problem?**
Took off the function that returns to the base name of pathname path.

**How did you make sure your solution works?**
Made some tests with .py examples.
